### PR TITLE
ci: adapt build-pro-image for v1 branch

### DIFF
--- a/.github/workflows/build-pro-image.yml
+++ b/.github/workflows/build-pro-image.yml
@@ -26,11 +26,16 @@ on:
 jobs:
   get-plugins:
     uses: nocobase/nocobase/.github/workflows/get-plugins.yml@main
+    with:
+      # For v1 builds, only include repos that have the v1 branch.
+      require_branch: ${{ inputs.branch == 'v1' && 'v1' || '' }}
     secrets: 
       NOCOBASE_APP_PRIVATE_KEY: ${{ secrets.NOCOBASE_APP_PRIVATE_KEY }}
   build-and-push:
     runs-on: ubuntu-latest
     needs: get-plugins
+    env:
+      BASE_REF: ${{ inputs.branch }}
     services:
       verdaccio:
         image: verdaccio/verdaccio:5
@@ -93,12 +98,12 @@ jobs:
         id: get-branch
         shell: bash
         run: |
-            echo "baseBranch=$(git branch --show-current)" >> $GITHUB_OUTPUT
+            echo "baseBranch=${{ env.BASE_REF }}" >> $GITHUB_OUTPUT
       - name: Checkout pro-plugins
         uses: actions/checkout@v3
         with:
           repository: nocobase/pro-plugins
-          ref: ${{ inputs.branch }}
+          ref: ${{ env.BASE_REF }}
           path: packages/pro-plugins
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
@@ -108,7 +113,7 @@ jobs:
         continue-on-error: true
         run: |
           cd ./packages/pro-plugins/
-          git checkout ${{ steps.get-branch.outputs.baseBranch }} || true
+          git checkout ${{ env.BASE_REF }} || true
           cd ../../
       - name: Checkout pro-plugins pr
         if: ${{ inputs.repository == 'pro-plugins' && inputs.pro_pr_number != '' }}
@@ -124,14 +129,14 @@ jobs:
         run: |
           for repo in ${{ join(fromJSON(steps.get-info.outputs.proRepos), ' ') }}
           do
-          git clone -b ${{ inputs.branch }} https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/nocobase/$repo.git packages/pro-plugins/@nocobase/$repo
+          git clone -b ${{ env.BASE_REF }} https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/nocobase/$repo.git packages/pro-plugins/@nocobase/$repo
           done
       - name: Clone pro repo
         shell: bash
         if: ${{ inputs.pro_plugin && inputs.pro_plugin != 'pro-plugins' }}
         run: |
           if [ ! -d "packages/pro-plugins/@nocobase/${{ inputs.repository }}" ]; then
-            git clone -b ${{ inputs.branch }} https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/nocobase/${{ inputs.repository }}.git packages/pro-plugins/@nocobase/${{ inputs.repository }}
+            git clone -b ${{ env.BASE_REF }} https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/nocobase/${{ inputs.repository }}.git packages/pro-plugins/@nocobase/${{ inputs.repository }}
           fi
       - name: Try checkout pro repos branch
         shell: bash
@@ -141,7 +146,7 @@ jobs:
           for plugins in ./packages/pro-plugins/@nocobase/*; do
             echo "$plugins"
             cd "$plugins"
-            git checkout ${{ steps.get-branch.outputs.baseBranch }} || true
+            git checkout ${{ env.BASE_REF }} || true
             cd ../../../../
           done
       - name: Checkout pro pr


### PR DESCRIPTION
Sync with nocobase/nocobase#8674: pass require_branch for v1 builds and use BASE_REF instead of current PR branch when checking out/cloning pro plugins.