### PR TITLE
refactor(ci): replace yarn with pnpm in build-pro-image workflow

### DIFF
--- a/.github/workflows/build-pro-image.yml
+++ b/.github/workflows/build-pro-image.yml
@@ -224,6 +224,10 @@ jobs:
           echo "CDN_ALI_OSS_ACCESS_KEY_SECRET=${{ secrets.CDN_ALI_OSS_ACCESS_KEY_SECRET }}" >> .env
           echo "CDN_ALI_OSS_BUCKET=${{ secrets.CDN_ALI_OSS_BUCKET }}" >> .env
           echo "CDN_ALI_OSS_REGION=${{ secrets.CDN_ALI_OSS_REGION }}" >> .env
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
       - name: build docs
         run: |
           set -e

--- a/.github/workflows/build-pro-image.yml
+++ b/.github/workflows/build-pro-image.yml
@@ -224,10 +224,10 @@ jobs:
           echo "CDN_ALI_OSS_ACCESS_KEY_SECRET=${{ secrets.CDN_ALI_OSS_ACCESS_KEY_SECRET }}" >> .env
           echo "CDN_ALI_OSS_BUCKET=${{ secrets.CDN_ALI_OSS_BUCKET }}" >> .env
           echo "CDN_ALI_OSS_REGION=${{ secrets.CDN_ALI_OSS_REGION }}" >> .env
+      - name: Enable corepack
+        run: corepack enable
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - name: build docs
         run: |
           set -e

--- a/.github/workflows/build-pro-image.yml
+++ b/.github/workflows/build-pro-image.yml
@@ -213,7 +213,7 @@ jobs:
           trimmed_variable=$(echo "$subdirectories" | xargs)
           packageNames="@nocobase/${trimmed_variable// / @nocobase/}"
           pluginNames="${trimmed_variable//plugin-/}"
-          BEFORE_PACK_NOCOBASE="yarn add @nocobase/plugin-notifications @nocobase/plugin-disable-pm-add $packageNames -W --production"
+          BEFORE_PACK_NOCOBASE="pnpm add @nocobase/plugin-notifications @nocobase/plugin-disable-pm-add $packageNames -w"
           APPEND_PRESET_LOCAL_PLUGINS="notifications,disable-pm-add,${pluginNames// /,}"
           echo "var1=$BEFORE_PACK_NOCOBASE" >> $GITHUB_OUTPUT
           echo "var2=$APPEND_PRESET_LOCAL_PLUGINS" >> $GITHUB_OUTPUT
@@ -234,7 +234,7 @@ jobs:
 
           cd docs
 
-          yarn install
+          pnpm install
 
           branch="${{ inputs.branch }}"
           nocobase_pr="${{ inputs.nocobase_pr_number }}"
@@ -255,8 +255,8 @@ jobs:
             ./build-all.sh
           else
             echo "Running normal build"
-            yarn build
-            yarn build --lang=cn
+            pnpm build
+            pnpm build --lang=cn
             tar -czf dist.tar.gz -C ./dist .
           fi
 


### PR DESCRIPTION
## Summary
- Replace `yarn` commands with `pnpm` equivalents in the build-pro-image workflow
- Update `BEFORE_PACK_NOCOBASE` from `yarn add ... -W --production` to `pnpm add ... -w`
- Update docs build commands from `yarn install/build` to `pnpm install/build`

## Changes
| Location | Before | After |
|----------|--------|-------|
| Line 216 | `yarn add ... -W --production` | `pnpm add ... -w` |
| Line 237 | `yarn install` | `pnpm install` |
| Line 258-259 | `yarn build` | `pnpm build` |

## Test plan
- [ ] Trigger build-pro-image workflow and verify it completes successfully
- [ ] Verify docs build step works correctly with pnpm

🤖 Generated with [Claude Code](https://claude.com/claude-code)