### PR TITLE
feat(build-pro-image): add parallel check-docs job for multi-language alignment

### DIFF
--- a/.github/workflows/build-pro-image.yml
+++ b/.github/workflows/build-pro-image.yml
@@ -291,33 +291,62 @@ jobs:
         if: steps.probe.outputs.skip != 'true'
         shell: bash
         run: |
+          if [ ! -f docs/scripts/check-home-alignment.mjs ]; then
+            echo "::notice::docs/scripts/check-home-alignment.mjs not found, skipping js-yaml install"
+            exit 0
+          fi
           cd docs
           npm install --no-save --no-package-lock --no-audit --no-fund js-yaml >/dev/null
 
       - name: Tree alignment
         if: steps.probe.outputs.skip != 'true'
         shell: bash
-        run: node docs/scripts/check-tree-alignment.mjs
+        run: |
+          if [ ! -f docs/scripts/check-tree-alignment.mjs ]; then
+            echo "::notice::docs/scripts/check-tree-alignment.mjs not found, skipping"
+            exit 0
+          fi
+          node docs/scripts/check-tree-alignment.mjs
 
       - name: Meta alignment
         if: steps.probe.outputs.skip != 'true'
         shell: bash
-        run: node docs/scripts/check-meta-alignment.mjs
+        run: |
+          if [ ! -f docs/scripts/check-meta-alignment.mjs ]; then
+            echo "::notice::docs/scripts/check-meta-alignment.mjs not found, skipping"
+            exit 0
+          fi
+          node docs/scripts/check-meta-alignment.mjs
 
       - name: Nav alignment
         if: steps.probe.outputs.skip != 'true'
         shell: bash
-        run: node docs/scripts/check-nav-alignment.mjs
+        run: |
+          if [ ! -f docs/scripts/check-nav-alignment.mjs ]; then
+            echo "::notice::docs/scripts/check-nav-alignment.mjs not found, skipping"
+            exit 0
+          fi
+          node docs/scripts/check-nav-alignment.mjs
 
       - name: Home alignment
         if: steps.probe.outputs.skip != 'true'
         shell: bash
-        run: node docs/scripts/check-home-alignment.mjs
+        run: |
+          if [ ! -f docs/scripts/check-home-alignment.mjs ]; then
+            echo "::notice::docs/scripts/check-home-alignment.mjs not found, skipping"
+            exit 0
+          fi
+          node docs/scripts/check-home-alignment.mjs
 
       - name: Bloated files
         if: steps.probe.outputs.skip != 'true'
         shell: bash
-        run: node docs/scripts/check-bloated-files.mjs
+        run: |
+          if [ ! -f docs/scripts/check-bloated-files.mjs ]; then
+            echo "::notice::docs/scripts/check-bloated-files.mjs not found, skipping"
+            exit 0
+          fi
+          node docs/scripts/check-bloated-files.mjs
 
   build-app:
     if: ${{ inputs.branch != 'v1' }}

--- a/.github/workflows/build-pro-image.yml
+++ b/.github/workflows/build-pro-image.yml
@@ -241,6 +241,84 @@ jobs:
             docker/
           retention-days: 1
 
+  check-docs:
+    if: ${{ inputs.branch != 'v1' }}
+    runs-on: ubuntu-latest
+    needs: prepare-meta
+    steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.NOCOBASE_APP_ID }}
+          private-key: ${{ secrets.NOCOBASE_APP_PRIVATE_KEY }}
+          owner: nocobase
+          repositories: nocobase
+          skip-token-revoke: true
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          repository: nocobase/nocobase
+          ref: ${{ inputs.branch }}
+          token: ${{ steps.app-token.outputs.token }}
+          submodules: true
+
+      - name: Checkout nocobase/nocobase pr
+        if: ${{ inputs.nocobase_pr_number != '' }}
+        shell: bash
+        run: |
+          gh pr checkout ${{ inputs.nocobase_pr_number }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Probe docs scripts
+        id: probe
+        shell: bash
+        run: |
+          if [ ! -d docs ] || [ ! -d docs/scripts ]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "Skipping: docs/ or docs/scripts/ not found on this branch"
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Install js-yaml (for check-home-alignment)
+        if: steps.probe.outputs.skip != 'true'
+        shell: bash
+        run: |
+          cd docs
+          npm install --no-save --no-package-lock --no-audit --no-fund js-yaml >/dev/null
+
+      - name: Tree alignment
+        if: steps.probe.outputs.skip != 'true'
+        shell: bash
+        run: node docs/scripts/check-tree-alignment.mjs
+
+      - name: Meta alignment
+        if: steps.probe.outputs.skip != 'true'
+        shell: bash
+        run: node docs/scripts/check-meta-alignment.mjs
+
+      - name: Nav alignment
+        if: steps.probe.outputs.skip != 'true'
+        shell: bash
+        run: node docs/scripts/check-nav-alignment.mjs
+
+      - name: Home alignment
+        if: steps.probe.outputs.skip != 'true'
+        shell: bash
+        run: node docs/scripts/check-home-alignment.mjs
+
+      - name: Bloated files
+        if: steps.probe.outputs.skip != 'true'
+        shell: bash
+        run: node docs/scripts/check-bloated-files.mjs
+
   build-app:
     if: ${{ inputs.branch != 'v1' }}
     runs-on: ubuntu-latest
@@ -577,13 +655,14 @@ jobs:
   update-status:
     if: ${{ inputs.checkRunId && always() }}
     runs-on: ubuntu-latest
-    needs: [ get-plugins, prepare-meta, build-docs, build-app, assemble-image ]
+    needs: [ get-plugins, prepare-meta, build-docs, build-app, assemble-image, check-docs ]
     env:
       GET_PLUGINS_RESULT: ${{ needs.get-plugins.result }}
       PREPARE_META_RESULT: ${{ needs.prepare-meta.result }}
       BUILD_DOCS_RESULT: ${{ needs.build-docs.result }}
       BUILD_APP_RESULT: ${{ needs.build-app.result }}
       ASSEMBLE_IMAGE_RESULT: ${{ needs.assemble-image.result }}
+      CHECK_DOCS_RESULT: ${{ needs.check-docs.result }}
     steps:
       - uses: actions/create-github-app-token@v1
         id: app-token
@@ -611,7 +690,8 @@ jobs:
             "$PREPARE_META_RESULT" \
             "$BUILD_DOCS_RESULT" \
             "$BUILD_APP_RESULT" \
-            "$ASSEMBLE_IMAGE_RESULT"
+            "$ASSEMBLE_IMAGE_RESULT" \
+            "$CHECK_DOCS_RESULT"
           do
             if [ "$result" != "skipped" ]; then
               all_skipped="false"


### PR DESCRIPTION
## Summary

Add a new `check-docs` job to the `build-pro-image` workflow that runs the five docs alignment / bloat detection scripts shipped in `nocobase/nocobase` under `docs/scripts/`.

## Behavior

- **Parallel with `build-docs`**: only depends on `prepare-meta`, runs alongside other jobs without blocking them.
- **Does not gate the image build**: `assemble-image` still depends only on `[ prepare-meta, build-docs, build-app ]`, so a docs misalignment will not block image build/push or deployment.
- **Affects final pipeline status**: `update-status.needs` and the result aggregation loop now include `check-docs`, so a failure there turns the overall check-run conclusion red, surfacing the misalignment to PR authors.
- **Branch-safe**: per-file existence checks mean branches missing one or more `docs/scripts/check-*.mjs` files (e.g. older branches, in-progress merges) skip those steps with a `::notice::` instead of failing.

## Steps

1. App-token + checkout + (optional) PR checkout (same pattern as `build-docs`).
2. `Probe docs scripts`: skips the whole job cleanly when `docs/` or `docs/scripts/` is absent (e.g. v1 dispatch path).
3. `Install js-yaml` (only if `check-home-alignment.mjs` exists). Uses `npm install --no-save` for ~5s install instead of full root + docs `yarn install`.
4. Five script steps, each gating on its own file existence and `exit 0` if missing.

## Dependency

The `docs/scripts/check-*.mjs` scripts come from nocobase/nocobase#9309 (PR to `next` branch). The probe + per-file guards make this workflow forward-compatible: it works today on branches without the scripts (skips quietly), and starts gating once the scripts land in the target branch.

## Test plan

- [ ] Manually dispatch `build-pro-image` against `next` branch (where the scripts will exist after #9309 merges) — expect `check-docs` to run all five steps.
- [ ] Manually dispatch against `main` (where scripts don't yet exist) — expect probe to no-op or per-file existence checks to skip every step with notices, job goes green.
- [ ] Verify `assemble-image` does not list `check-docs` in its `needs` (so a forced `check-docs` failure still produces an image).
- [ ] Verify final `update-status` conclusion turns red when `check-docs` fails.
