### PR TITLE
feat(build-pro-image): add i18n coverage step to check-docs job

### DIFF
--- a/.github/workflows/build-pro-image.yml
+++ b/.github/workflows/build-pro-image.yml
@@ -348,6 +348,40 @@ jobs:
           fi
           node docs/scripts/check-bloated-files.mjs
 
+      - name: i18n coverage (PR cn changes synced to other languages)
+        if: steps.probe.outputs.skip != 'true' && inputs.nocobase_pr_number != ''
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          if [ ! -f docs/scripts/check-i18n-coverage.mjs ]; then
+            echo "::notice::docs/scripts/check-i18n-coverage.mjs not found, skipping"
+            exit 0
+          fi
+
+          PR_NUM="${{ inputs.nocobase_pr_number }}"
+          REPO="nocobase/${{ inputs.repository || 'nocobase' }}"
+
+          # Opt-out: PR labeled `skip-i18n-check` bypasses this step entirely.
+          # The label exists in nocobase/nocobase; for other repos there's nothing to check.
+          if [ "$REPO" = "nocobase/nocobase" ]; then
+            if gh pr view "$PR_NUM" --repo "$REPO" --json labels --jq '.labels[].name' | grep -qx 'skip-i18n-check'; then
+              echo "::notice::PR $PR_NUM has skip-i18n-check label, bypassing i18n coverage check"
+              exit 0
+            fi
+          fi
+
+          # Pull the PR's changed-file list directly from GitHub. Avoid `git diff origin/<base>...HEAD`
+          # because actions/checkout is shallow and the base ref isn't fetched.
+          gh pr view "$PR_NUM" --repo "$REPO" --json files --jq '.files[].path' > /tmp/changed-files.txt
+
+          if [ ! -s /tmp/changed-files.txt ]; then
+            echo "No changed files reported for PR $PR_NUM; skipping"
+            exit 0
+          fi
+
+          cat /tmp/changed-files.txt | node docs/scripts/check-i18n-coverage.mjs
+
   build-app:
     if: ${{ inputs.branch != 'v1' }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Add an `i18n coverage` step to the existing `check-docs` job. Pairs with the new `docs/scripts/check-i18n-coverage.mjs` script in nocobase/nocobase#9310.

## What it does

Flags `cn .md/.mdx` content edits in the current PR that weren't synced to the other nine maintained languages (en/ja/es/pt/de/fr/ru/id/vi). The five existing alignment scripts only catch structural drift (file added/removed, _meta.json link change, etc.); this step catches content drift — e.g. a one-line edit to cn that other languages didn't follow.

## Behavior

- **PR-only**: gated on `inputs.nocobase_pr_number != ''`. Nightly / branch builds skip the step cleanly.
- **Forward compatible**: probes for `docs/scripts/check-i18n-coverage.mjs` before invoking node. Branches without the script (anything older than nocobase/nocobase#9310) `exit 0` with a `::notice::`.
- **Avoids `git diff`**: pulls the changed-file list via `gh pr view --json files`. `actions/checkout` produces a shallow clone where the base ref isn't fetched, so `git diff origin/<base>...HEAD` would fail.
- **Opt-out via label**: PRs in nocobase/nocobase labeled `skip-i18n-check` bypass the step. The label is intended for cn-only typo / China-specific notes / cosmetic-only edits that genuinely don't need translation. Adding the label requires repo write access, so it can't be silently abused.

## Direction

One-way: cn → others. Single-language fixes (en typo, etc.) are not flagged — those are legitimate translation corrections.

## Dependency

`docs/scripts/check-i18n-coverage.mjs` ships in nocobase/nocobase#9310 (PR to `next`). The probe + per-file guards ensure this workflow tolerates the staggered rollout: it works today on branches without the script (skips), and starts gating once #9310 lands in the target branch.

## Test plan

- [ ] Manually dispatch `build-pro-image` against a `next`-based PR that modifies a single `cn/foo.md` without touching the other languages — expect `i18n coverage` step red, `assemble-image` still green, `update-status` red.
- [ ] Modify the same PR to also touch the other 9 language files — re-dispatch, expect green.
- [ ] Apply `skip-i18n-check` label to the failing-state PR and re-dispatch — expect step prints "bypassing" notice and exits 0.
- [ ] Dispatch against `main` (no PR number) — expect step skipped cleanly via the `if:` guard.
