### PR TITLE
fix(build-pro-image): paginate PR file list in i18n coverage check

### DIFF
--- a/.github/workflows/build-pro-image.yml
+++ b/.github/workflows/build-pro-image.yml
@@ -377,13 +377,26 @@ jobs:
             fi
           fi
 
-          # Pull the PR's changed-file list directly from GitHub. Avoid `git diff origin/<base>...HEAD`
-          # because actions/checkout is shallow and the base ref isn't fetched.
-          gh pr view "$PR_NUM" --repo "$REPO" --json files --jq '.files[].path' > /tmp/changed-files.txt
+          # Pull the PR's changed-file list via the REST files endpoint with --paginate.
+          # `gh pr view --json files` returns only the first 100 files (alphabetic) and is
+          # silently lossy for any PR larger than that, producing bogus STALE results.
+          # `git diff origin/<base>...HEAD` won't work either: actions/checkout is shallow
+          # and doesn't fetch the base ref.
+          # The REST endpoint paginates up to GitHub's server-side hard cap of 3000 files;
+          # we warn (not fail) when a PR exceeds the cap so the user can decide whether to
+          # `skip-i18n-check` or split the PR.
+          gh api "repos/$REPO/pulls/$PR_NUM/files?per_page=100" --paginate \
+            --jq '.[].filename' > /tmp/changed-files.txt
 
           if [ ! -s /tmp/changed-files.txt ]; then
             echo "No changed files reported for PR $PR_NUM; skipping"
             exit 0
+          fi
+
+          TOTAL_FILES=$(gh pr view "$PR_NUM" --repo "$REPO" --json changedFiles --jq '.changedFiles')
+          GOT_FILES=$(wc -l < /tmp/changed-files.txt | tr -d ' ')
+          if [ "$TOTAL_FILES" -gt "$GOT_FILES" ]; then
+            echo "::warning::PR has $TOTAL_FILES changed files but GitHub returned only $GOT_FILES (3000-file API cap). i18n coverage check will be partial; add 'skip-i18n-check' label to bypass."
           fi
 
           cat /tmp/changed-files.txt | node scripts/check-i18n-coverage.mjs


### PR DESCRIPTION
## Problem

The i18n coverage step in `check-docs` uses:

```bash
gh pr view "$PR_NUM" --repo "$REPO" --json files --jq '.files[].path' > /tmp/changed-files.txt
```

`gh pr view --json files` is GraphQL-backed and only returns the **first 100 files** of a PR (alphabetically). It silently truncates beyond that.

For any PR larger than 100 files, the script ends up seeing only the alphabetically-earliest slice of changes (typically just `cn/` plus whatever else fits) and reports every other language as STALE, even when the same files were changed across all locales.

Concrete repro on nocobase/nocobase#9371: PR has 4609 changed files; the API returned only 100 (cn 11 + de 88 + 1 other). The check then claimed cn changes weren't synced to en/ja/es/etc., even though those files were all modified.

## Fix

- Switch to the REST `pulls/{num}/files` endpoint with `gh api ... --paginate`. This pages through up to GitHub's hard cap of 3000 files.
- For PRs that exceed the 3000-file cap, emit a workflow warning so reviewers know the i18n coverage check is only partial and can decide whether to apply the `skip-i18n-check` label.
- The 3000-file cap is GitHub's, not ours; can't be fixed on the client side.

## Test plan

- Existing skip-i18n-check label opt-out path is unchanged.
- For a normal-size PR (<3000 files), behaviour is identical except correct.
- For a >3000-file PR, the warning fires; the script still runs against the partial list (best-effort), which can produce false STALE flags for langs whose files happened to fall outside the 3000-file window — same situation as before for very large PRs, just now signposted instead of silent.
