### PR TITLE
feat(build-pro-image): add parallel check-and-build-with-types job

### DIFF
--- a/.github/workflows/build-pro-image.yml
+++ b/.github/workflows/build-pro-image.yml
@@ -401,6 +401,162 @@ jobs:
 
           cat /tmp/changed-files.txt | node scripts/check-i18n-coverage.mjs
 
+  check-and-build-with-types:
+    if: ${{ inputs.branch != 'v1' }}
+    runs-on: ubuntu-latest
+    needs: [ get-plugins, prepare-meta ]
+    env:
+      BASE_REF: ${{ inputs.branch }}
+    steps:
+      # ====== setup steps mirror build-app job; keep in sync until extracted to a composite action ======
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.NOCOBASE_APP_ID }}
+          private-key: ${{ secrets.NOCOBASE_APP_PRIVATE_KEY }}
+          owner: nocobase
+          repositories: nocobase,pro-plugins,${{ inputs.repository || 'nocobase' }},${{
+            join(fromJSON(needs.get-plugins.outputs.all-plugins || '[]'), ',')
+            }}
+          skip-token-revoke: true
+
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          repository: nocobase/nocobase
+          ref: ${{ inputs.branch }}
+          token: ${{ steps.app-token.outputs.token }}
+          submodules: true
+
+      - name: Checkout nocobase/nocobase pr
+        if: ${{ inputs.nocobase_pr_number != '' }}
+        shell: bash
+        run: |
+          gh pr checkout ${{ inputs.nocobase_pr_number }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Get branch
+        id: get-branch
+        shell: bash
+        run: |
+          echo "baseBranch=$(git branch --show-current)" >> $GITHUB_OUTPUT
+
+      - name: Checkout pro-plugins
+        uses: actions/checkout@v5
+        with:
+          repository: nocobase/pro-plugins
+          ref: ${{ env.BASE_REF }}
+          path: packages/pro-plugins
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Try checkout pro-plugins branch
+        if: ${{ inputs.repository != 'pro-plugins' || inputs.pro_pr_number == '' }}
+        shell: bash
+        continue-on-error: true
+        run: |
+          cd ./packages/pro-plugins/
+          git checkout ${{ steps.get-branch.outputs.baseBranch }} || true
+          cd ../../
+
+      - name: Checkout pro-plugins pr
+        if: ${{ inputs.repository == 'pro-plugins' && inputs.pro_pr_number != '' }}
+        shell: bash
+        run: |
+          cd ./packages/pro-plugins/
+          gh pr checkout ${{ inputs.pro_pr_number }}
+          cd ../../
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Clone pro repos
+        shell: bash
+        run: |
+          for repo in ${{ join(fromJSON(needs.prepare-meta.outputs.proRepos || '[]'), ' ') }}
+          do
+            git clone -b ${{ env.BASE_REF }} https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/nocobase/$repo.git packages/pro-plugins/@nocobase/$repo
+          done
+
+      - name: Clone pro repo
+        shell: bash
+        if: ${{ inputs.pro_plugin && inputs.pro_plugin != 'pro-plugins' }}
+        run: |
+          if [ ! -d "packages/pro-plugins/@nocobase/${{ inputs.repository }}" ]; then
+            git clone -b ${{ env.BASE_REF }} https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/nocobase/${{ inputs.repository }}.git packages/pro-plugins/@nocobase/${{ inputs.repository }}
+          fi
+
+      - name: Try checkout pro repos branch
+        shell: bash
+        continue-on-error: true
+        run: |
+          for plugins in ./packages/pro-plugins/@nocobase/*; do
+            if [ ! -e "$plugins/.git" ]; then
+              echo "Skip non-git plugin path: $plugins"
+              continue
+            fi
+            echo "$plugins"
+            git -C "$plugins" checkout ${{ steps.get-branch.outputs.baseBranch }} || true
+          done
+
+      - name: Checkout pro pr
+        if: ${{ inputs.pro_plugin && inputs.pro_plugin != 'pro-plugins' &&
+          inputs.pro_pr_number != '' }}
+        shell: bash
+        run: |
+          cd ./packages/pro-plugins/@nocobase/${{ inputs.repository }}
+          gh pr checkout ${{ inputs.pro_pr_number }}
+          cd ../../../../
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+      # ====== end of build-app shared setup ======
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Probe peer-deps scripts
+        id: probe
+        shell: bash
+        run: |
+          if [ ! -f scripts/check-plugin-peer-deps.sh ] || [ ! -f scripts/peer-deps-whitelist.json ]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "::notice::scripts/check-plugin-peer-deps.sh not found on this branch, skipping peer-deps check"
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run peer-deps check
+        if: steps.probe.outputs.skip != 'true'
+        shell: bash
+        run: |
+          exit_code=0
+          if [[ -d packages/plugins/@nocobase ]]; then
+            echo "::group::Checking packages/plugins/@nocobase"
+            bash scripts/check-plugin-peer-deps.sh packages/plugins/@nocobase \
+              --whitelist scripts/peer-deps-whitelist.json || exit_code=1
+            echo "::endgroup::"
+          fi
+          if [[ -d packages/pro-plugins/@nocobase ]]; then
+            echo "::group::Checking packages/pro-plugins/@nocobase"
+            bash scripts/check-plugin-peer-deps.sh packages/pro-plugins/@nocobase \
+              --whitelist scripts/peer-deps-whitelist.json || exit_code=1
+            echo "::endgroup::"
+          fi
+          if [[ $exit_code -ne 0 ]]; then
+            echo "::error::Missing plugin-* peerDependencies detected. See details above."
+            exit 1
+          fi
+
+      - name: Install and build (with type definitions)
+        shell: bash
+        run: |
+          yarn config set registry https://registry.npmjs.org/
+          sed -i 's/registry.npmmirror.com/registry.npmjs.org/g' yarn.lock || true
+          yarn install
+          yarn build
+
   build-app:
     if: ${{ inputs.branch != 'v1' }}
     runs-on: ubuntu-latest
@@ -751,7 +907,7 @@ jobs:
   update-status:
     if: ${{ inputs.checkRunId && always() }}
     runs-on: ubuntu-latest
-    needs: [ get-plugins, prepare-meta, build-docs, build-app, assemble-image, check-docs ]
+    needs: [ get-plugins, prepare-meta, build-docs, build-app, assemble-image, check-docs, check-and-build-with-types ]
     env:
       GET_PLUGINS_RESULT: ${{ needs.get-plugins.result }}
       PREPARE_META_RESULT: ${{ needs.prepare-meta.result }}
@@ -759,6 +915,7 @@ jobs:
       BUILD_APP_RESULT: ${{ needs.build-app.result }}
       ASSEMBLE_IMAGE_RESULT: ${{ needs.assemble-image.result }}
       CHECK_DOCS_RESULT: ${{ needs.check-docs.result }}
+      CHECK_AND_BUILD_RESULT: ${{ needs.check-and-build-with-types.result }}
     steps:
       - uses: actions/create-github-app-token@v2
         id: app-token
@@ -787,7 +944,8 @@ jobs:
             "$BUILD_DOCS_RESULT" \
             "$BUILD_APP_RESULT" \
             "$ASSEMBLE_IMAGE_RESULT" \
-            "$CHECK_DOCS_RESULT"
+            "$CHECK_DOCS_RESULT" \
+            "$CHECK_AND_BUILD_RESULT"
           do
             if [ "$result" != "skipped" ]; then
               all_skipped="false"


### PR DESCRIPTION
## Summary
- Adds a parallel `check-and-build-with-types` job to `build-pro-image.yml`, sitting alongside `build-app` / `build-docs` / `check-docs`. It runs **peer-deps validation** followed by a **full `yarn build` (with dts)** — neither of which the existing pipeline covers, since `build-app` uses `--no-dts` to speed up image assembly.
- **peer-deps step is probe-and-skip**: gracefully no-ops on branches that don't ship `scripts/check-plugin-peer-deps.sh` (currently `main`). On `develop`/`next` it runs the script against `packages/plugins/@nocobase` and `packages/pro-plugins/@nocobase`.
- **`assemble-image` does not depend on the new job** — image builds are never blocked by check or type failures, so reviewers can still pull the image for testing. The final conclusion in `update-status` does include the new job's result, so a PR check turns red on failure.
- Setup steps (token, checkout, pro-plugins clone, standalone pro repo clones, PR checkouts) mirror `build-app`'s sequence verbatim. A later PR will extract them into a composite action once this job stabilizes.

## Test plan
- [x] **Smoke**: `workflow_dispatch` with `branch=next`, no PR — expect new job ✅, `assemble-image` ✅, all existing jobs unchanged.
- [ ] **Negative (peer-deps)**: dispatch on a PR that intentionally drops a `plugin-*` peerDependency — expect "Run peer-deps check" step ❌, "Install and build" step skipped, image ✅, final conclusion failure.
- [ ] **Negative (types)**: dispatch on a PR with a dts-only type error — expect "Install and build" step ❌, image ✅.
- [ ] **`main` fallback**: dispatch with `branch=main` — "Run peer-deps check" probe-skipped (notice in log), "Install and build" runs normally.
- [ ] **v1**: dispatch with `branch=v1` — new job skipped via `if:`, dispatch-v1 sub-workflow runs as before.