### PR TITLE
refactor(build-pro-image): extract shared setup into composite action

### DIFF
--- a/.github/actions/setup-nocobase-workspace/action.yml
+++ b/.github/actions/setup-nocobase-workspace/action.yml
@@ -1,4 +1,4 @@
-name: 'Setup pro workspace'
+name: 'Setup nocobase workspace'
 description: 'Mint a GitHub App token, then checkout nocobase + pro-plugins + standalone pro plugin repos with PR checkouts applied. Used by build-app and check-and-build-with-types.'
 
 inputs:

--- a/.github/actions/setup-pro-workspace/action.yml
+++ b/.github/actions/setup-pro-workspace/action.yml
@@ -1,0 +1,146 @@
+name: 'Setup pro workspace'
+description: 'Mint a GitHub App token, then checkout nocobase + pro-plugins + standalone pro plugin repos with PR checkouts applied. Used by build-app and check-and-build-with-types.'
+
+inputs:
+  branch:
+    description: 'Base branch (e.g. main, develop, next)'
+    required: true
+  nocobase_pr_number:
+    description: 'PR number in the nocobase repo to checkout, if any'
+    required: false
+    default: ''
+  pro_pr_number:
+    description: 'PR number in the pro plugin repo to checkout, if any'
+    required: false
+    default: ''
+  pro_plugin:
+    description: 'Pro plugin name (either ''pro-plugins'' or a single plugin-* name)'
+    required: false
+    default: ''
+  repository:
+    description: 'Pro plugin repository name (defaults to nocobase)'
+    required: false
+    default: 'nocobase'
+  pro_repos:
+    description: 'JSON array of pro repo names to clone (typically prepare-meta.outputs.proRepos)'
+    required: false
+    default: '[]'
+  all_plugins:
+    description: 'JSON array of all-plugins from get-plugins (used to scope the GitHub App token)'
+    required: false
+    default: '[]'
+  app_id:
+    description: 'GitHub App ID for minting the installation token'
+    required: true
+  app_private_key:
+    description: 'GitHub App private key for minting the installation token'
+    required: true
+
+outputs:
+  app_token:
+    description: 'The GitHub App installation token (use for subsequent gh/git operations)'
+    value: ${{ steps.app-token.outputs.token }}
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/create-github-app-token@v2
+      id: app-token
+      with:
+        app-id: ${{ inputs.app_id }}
+        private-key: ${{ inputs.app_private_key }}
+        owner: nocobase
+        repositories: nocobase,pro-plugins,${{ inputs.repository || 'nocobase' }},${{
+          join(fromJSON(inputs.all_plugins || '[]'), ',')
+          }}
+        skip-token-revoke: true
+
+    - name: Checkout
+      uses: actions/checkout@v5
+      with:
+        repository: nocobase/nocobase
+        ref: ${{ inputs.branch }}
+        token: ${{ steps.app-token.outputs.token }}
+        submodules: true
+
+    - name: Checkout nocobase/nocobase pr
+      if: ${{ inputs.nocobase_pr_number != '' }}
+      shell: bash
+      run: |
+        gh pr checkout ${{ inputs.nocobase_pr_number }}
+      env:
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+    - name: Get branch
+      id: get-branch
+      shell: bash
+      run: |
+        echo "baseBranch=$(git branch --show-current)" >> $GITHUB_OUTPUT
+
+    - name: Checkout pro-plugins
+      uses: actions/checkout@v5
+      with:
+        repository: nocobase/pro-plugins
+        ref: ${{ inputs.branch }}
+        path: packages/pro-plugins
+        fetch-depth: 0
+        token: ${{ steps.app-token.outputs.token }}
+
+    - name: Try checkout pro-plugins branch
+      if: ${{ inputs.repository != 'pro-plugins' || inputs.pro_pr_number == '' }}
+      shell: bash
+      continue-on-error: true
+      run: |
+        cd ./packages/pro-plugins/
+        git checkout ${{ steps.get-branch.outputs.baseBranch }} || true
+        cd ../../
+
+    - name: Checkout pro-plugins pr
+      if: ${{ inputs.repository == 'pro-plugins' && inputs.pro_pr_number != '' }}
+      shell: bash
+      run: |
+        cd ./packages/pro-plugins/
+        gh pr checkout ${{ inputs.pro_pr_number }}
+        cd ../../
+      env:
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+    - name: Clone pro repos
+      shell: bash
+      run: |
+        for repo in ${{ join(fromJSON(inputs.pro_repos || '[]'), ' ') }}
+        do
+          git clone -b ${{ inputs.branch }} https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/nocobase/$repo.git packages/pro-plugins/@nocobase/$repo
+        done
+
+    - name: Clone pro repo
+      shell: bash
+      if: ${{ inputs.pro_plugin && inputs.pro_plugin != 'pro-plugins' }}
+      run: |
+        if [ ! -d "packages/pro-plugins/@nocobase/${{ inputs.repository }}" ]; then
+          git clone -b ${{ inputs.branch }} https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/nocobase/${{ inputs.repository }}.git packages/pro-plugins/@nocobase/${{ inputs.repository }}
+        fi
+
+    - name: Try checkout pro repos branch
+      shell: bash
+      continue-on-error: true
+      run: |
+        for plugins in ./packages/pro-plugins/@nocobase/*; do
+          if [ ! -e "$plugins/.git" ]; then
+            echo "Skip non-git plugin path: $plugins"
+            continue
+          fi
+          echo "$plugins"
+          git -C "$plugins" checkout ${{ steps.get-branch.outputs.baseBranch }} || true
+        done
+
+    - name: Checkout pro pr
+      if: ${{ inputs.pro_plugin && inputs.pro_plugin != 'pro-plugins' &&
+        inputs.pro_pr_number != '' }}
+      shell: bash
+      run: |
+        cd ./packages/pro-plugins/@nocobase/${{ inputs.repository }}
+        gh pr checkout ${{ inputs.pro_pr_number }}
+        cd ../../../../
+      env:
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/build-pro-image.yml
+++ b/.github/workflows/build-pro-image.yml
@@ -405,111 +405,19 @@ jobs:
     if: ${{ inputs.branch != 'v1' }}
     runs-on: ubuntu-latest
     needs: [ get-plugins, prepare-meta ]
-    env:
-      BASE_REF: ${{ inputs.branch }}
     steps:
-      # ====== setup steps mirror build-app job; keep in sync until extracted to a composite action ======
-      - uses: actions/create-github-app-token@v2
-        id: app-token
+      - name: Setup pro workspace
+        uses: ./.github/actions/setup-pro-workspace
         with:
-          app-id: ${{ vars.NOCOBASE_APP_ID }}
-          private-key: ${{ secrets.NOCOBASE_APP_PRIVATE_KEY }}
-          owner: nocobase
-          repositories: nocobase,pro-plugins,${{ inputs.repository || 'nocobase' }},${{
-            join(fromJSON(needs.get-plugins.outputs.all-plugins || '[]'), ',')
-            }}
-          skip-token-revoke: true
-
-      - name: Checkout
-        uses: actions/checkout@v5
-        with:
-          repository: nocobase/nocobase
-          ref: ${{ inputs.branch }}
-          token: ${{ steps.app-token.outputs.token }}
-          submodules: true
-
-      - name: Checkout nocobase/nocobase pr
-        if: ${{ inputs.nocobase_pr_number != '' }}
-        shell: bash
-        run: |
-          gh pr checkout ${{ inputs.nocobase_pr_number }}
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-
-      - name: Get branch
-        id: get-branch
-        shell: bash
-        run: |
-          echo "baseBranch=$(git branch --show-current)" >> $GITHUB_OUTPUT
-
-      - name: Checkout pro-plugins
-        uses: actions/checkout@v5
-        with:
-          repository: nocobase/pro-plugins
-          ref: ${{ env.BASE_REF }}
-          path: packages/pro-plugins
-          fetch-depth: 0
-          token: ${{ steps.app-token.outputs.token }}
-
-      - name: Try checkout pro-plugins branch
-        if: ${{ inputs.repository != 'pro-plugins' || inputs.pro_pr_number == '' }}
-        shell: bash
-        continue-on-error: true
-        run: |
-          cd ./packages/pro-plugins/
-          git checkout ${{ steps.get-branch.outputs.baseBranch }} || true
-          cd ../../
-
-      - name: Checkout pro-plugins pr
-        if: ${{ inputs.repository == 'pro-plugins' && inputs.pro_pr_number != '' }}
-        shell: bash
-        run: |
-          cd ./packages/pro-plugins/
-          gh pr checkout ${{ inputs.pro_pr_number }}
-          cd ../../
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-
-      - name: Clone pro repos
-        shell: bash
-        run: |
-          for repo in ${{ join(fromJSON(needs.prepare-meta.outputs.proRepos || '[]'), ' ') }}
-          do
-            git clone -b ${{ env.BASE_REF }} https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/nocobase/$repo.git packages/pro-plugins/@nocobase/$repo
-          done
-
-      - name: Clone pro repo
-        shell: bash
-        if: ${{ inputs.pro_plugin && inputs.pro_plugin != 'pro-plugins' }}
-        run: |
-          if [ ! -d "packages/pro-plugins/@nocobase/${{ inputs.repository }}" ]; then
-            git clone -b ${{ env.BASE_REF }} https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/nocobase/${{ inputs.repository }}.git packages/pro-plugins/@nocobase/${{ inputs.repository }}
-          fi
-
-      - name: Try checkout pro repos branch
-        shell: bash
-        continue-on-error: true
-        run: |
-          for plugins in ./packages/pro-plugins/@nocobase/*; do
-            if [ ! -e "$plugins/.git" ]; then
-              echo "Skip non-git plugin path: $plugins"
-              continue
-            fi
-            echo "$plugins"
-            git -C "$plugins" checkout ${{ steps.get-branch.outputs.baseBranch }} || true
-          done
-
-      - name: Checkout pro pr
-        if: ${{ inputs.pro_plugin && inputs.pro_plugin != 'pro-plugins' &&
-          inputs.pro_pr_number != '' }}
-        shell: bash
-        run: |
-          cd ./packages/pro-plugins/@nocobase/${{ inputs.repository }}
-          gh pr checkout ${{ inputs.pro_pr_number }}
-          cd ../../../../
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-      # ====== end of build-app shared setup ======
+          branch: ${{ inputs.branch }}
+          nocobase_pr_number: ${{ inputs.nocobase_pr_number || '' }}
+          pro_pr_number: ${{ inputs.pro_pr_number || '' }}
+          pro_plugin: ${{ inputs.pro_plugin || '' }}
+          repository: ${{ inputs.repository || 'nocobase' }}
+          pro_repos: ${{ needs.prepare-meta.outputs.proRepos || '[]' }}
+          all_plugins: ${{ needs.get-plugins.outputs.all-plugins || '[]' }}
+          app_id: ${{ vars.NOCOBASE_APP_ID }}
+          app_private_key: ${{ secrets.NOCOBASE_APP_PRIVATE_KEY }}
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -564,7 +472,6 @@ jobs:
     outputs:
       installNbCli: ${{ steps.vars.outputs.installNbCli }}
     env:
-      BASE_REF: ${{ inputs.branch }}
       PLUGINS_DIRS: pro-plugins
     services:
       verdaccio:
@@ -578,106 +485,18 @@ jobs:
           docker exec -u root $CONTAINER_ID sh -c "echo 'max_body_size: 500mb' >> /verdaccio/conf/config.yaml"
           docker restart $CONTAINER_ID
 
-      - uses: actions/create-github-app-token@v2
-        id: app-token
+      - name: Setup pro workspace
+        uses: ./.github/actions/setup-pro-workspace
         with:
-          app-id: ${{ vars.NOCOBASE_APP_ID }}
-          private-key: ${{ secrets.NOCOBASE_APP_PRIVATE_KEY }}
-          owner: nocobase
-          repositories: nocobase,pro-plugins,${{ inputs.repository || 'nocobase' }},${{
-            join(fromJSON(needs.get-plugins.outputs.all-plugins || '[]'), ',')
-            }}
-          skip-token-revoke: true
-
-      - name: Checkout
-        uses: actions/checkout@v5
-        with:
-          repository: nocobase/nocobase
-          ref: ${{ inputs.branch }}
-          token: ${{ steps.app-token.outputs.token }}
-          submodules: true
-
-      - name: Checkout nocobase/nocobase pr
-        if: ${{ inputs.nocobase_pr_number != '' }}
-        shell: bash
-        run: |
-          gh pr checkout ${{ inputs.nocobase_pr_number }}
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-
-      - name: Get branch
-        id: get-branch
-        shell: bash
-        run: |
-          echo "baseBranch=$(git branch --show-current)" >> $GITHUB_OUTPUT
-
-      - name: Checkout pro-plugins
-        uses: actions/checkout@v5
-        with:
-          repository: nocobase/pro-plugins
-          ref: ${{ env.BASE_REF }}
-          path: packages/pro-plugins
-          fetch-depth: 0
-          token: ${{ steps.app-token.outputs.token }}
-
-      - name: Try checkout pro-plugins branch
-        if: ${{ inputs.repository != 'pro-plugins' || inputs.pro_pr_number == '' }}
-        shell: bash
-        continue-on-error: true
-        run: |
-          cd ./packages/pro-plugins/
-          git checkout ${{ steps.get-branch.outputs.baseBranch }} || true
-          cd ../../
-
-      - name: Checkout pro-plugins pr
-        if: ${{ inputs.repository == 'pro-plugins' && inputs.pro_pr_number != '' }}
-        shell: bash
-        run: |
-          cd ./packages/pro-plugins/
-          gh pr checkout ${{ inputs.pro_pr_number }}
-          cd ../../
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-
-      - name: Clone pro repos
-        shell: bash
-        run: |
-          for repo in ${{ join(fromJSON(needs.prepare-meta.outputs.proRepos || '[]'), ' ') }}
-          do
-            git clone -b ${{ env.BASE_REF }} https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/nocobase/$repo.git packages/pro-plugins/@nocobase/$repo
-          done
-
-      - name: Clone pro repo
-        shell: bash
-        if: ${{ inputs.pro_plugin && inputs.pro_plugin != 'pro-plugins' }}
-        run: |
-          if [ ! -d "packages/pro-plugins/@nocobase/${{ inputs.repository }}" ]; then
-            git clone -b ${{ env.BASE_REF }} https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/nocobase/${{ inputs.repository }}.git packages/pro-plugins/@nocobase/${{ inputs.repository }}
-          fi
-
-      - name: Try checkout pro repos branch
-        shell: bash
-        continue-on-error: true
-        run: |
-          for plugins in ./packages/pro-plugins/@nocobase/*; do
-            if [ ! -e "$plugins/.git" ]; then
-              echo "Skip non-git plugin path: $plugins"
-              continue
-            fi
-            echo "$plugins"
-            git -C "$plugins" checkout ${{ steps.get-branch.outputs.baseBranch }} || true
-          done
-
-      - name: Checkout pro pr
-        if: ${{ inputs.pro_plugin && inputs.pro_plugin != 'pro-plugins' &&
-          inputs.pro_pr_number != '' }}
-        shell: bash
-        run: |
-          cd ./packages/pro-plugins/@nocobase/${{ inputs.repository }}
-          gh pr checkout ${{ inputs.pro_pr_number }}
-          cd ../../../../
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          branch: ${{ inputs.branch }}
+          nocobase_pr_number: ${{ inputs.nocobase_pr_number || '' }}
+          pro_pr_number: ${{ inputs.pro_pr_number || '' }}
+          pro_plugin: ${{ inputs.pro_plugin || '' }}
+          repository: ${{ inputs.repository || 'nocobase' }}
+          pro_repos: ${{ needs.prepare-meta.outputs.proRepos || '[]' }}
+          all_plugins: ${{ needs.get-plugins.outputs.all-plugins || '[]' }}
+          app_id: ${{ vars.NOCOBASE_APP_ID }}
+          app_private_key: ${{ secrets.NOCOBASE_APP_PRIVATE_KEY }}
 
       - name: rm .git
         run: |

--- a/.github/workflows/build-pro-image.yml
+++ b/.github/workflows/build-pro-image.yml
@@ -407,7 +407,7 @@ jobs:
     needs: [ get-plugins, prepare-meta ]
     steps:
       - name: Setup pro workspace
-        uses: ./.github/actions/setup-pro-workspace
+        uses: ./.github/actions/setup-nocobase-workspace
         with:
           branch: ${{ inputs.branch }}
           nocobase_pr_number: ${{ inputs.nocobase_pr_number || '' }}
@@ -486,7 +486,7 @@ jobs:
           docker restart $CONTAINER_ID
 
       - name: Setup pro workspace
-        uses: ./.github/actions/setup-pro-workspace
+        uses: ./.github/actions/setup-nocobase-workspace
         with:
           branch: ${{ inputs.branch }}
           nocobase_pr_number: ${{ inputs.nocobase_pr_number || '' }}


### PR DESCRIPTION
## Summary
- Extracts ~100 lines of duplicated workspace-setup steps (mint app token, checkout `nocobase/nocobase`, clone `pro-plugins`, clone standalone pro repos, PR checkouts) from `build-app` and `check-and-build-with-types` into a new composite action at `.github/actions/setup-pro-workspace/action.yml`.
- Both callers now invoke it via a single `uses:` step. Future changes to the clone sequence land in one place instead of being duplicated.
- **Job topology and behavior are unchanged**: same 9 jobs, same `needs:` graph, same `if:` gates. Local verification with PyYAML confirms identical topology vs `main`.
- Also drops the now-dead `BASE_REF` env declaration in both jobs (the composite action takes `inputs.branch` directly).

## Test plan
- [ ] **Smoke**: workflow_dispatch with `branch=next`, no PR — expect all jobs ✅, no behavior change vs main.
- [ ] **PR variant — nocobase PR**: dispatch with a `nocobase_pr_number` set — expect both jobs to `gh pr checkout` the PR.
- [ ] **PR variant — pro plugin PR**: dispatch with `repository=plugin-something`, `pro_pr_number=<n>` — expect that pro repo's PR checked out inside `packages/pro-plugins/@nocobase/<repo>`.
- [ ] **PR variant — pro-plugins PR**: dispatch with `repository=pro-plugins`, `pro_pr_number=<n>` — expect `pro-plugins` itself to checkout the PR.
- [ ] **v1**: dispatch with `branch=v1` — both new-style jobs skipped via `if:` (composite action never invoked), `dispatch-v1` sub-workflow runs as before.