### PR TITLE
feat: dispatch E2E worker after pro image build

### DIFF
--- a/.github/workflows/build-pro-image.yml
+++ b/.github/workflows/build-pro-image.yml
@@ -934,39 +934,79 @@ jobs:
         continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          DISPATCH_ID: build-pro-${{ github.run_id }}-${{ github.run_attempt }}
+          CALLER_REPO: ${{ github.repository }}
+          CALLER_RUN_ID: ${{ github.run_id }}
+          CALLER_SHA: ${{ github.sha }}
+          IMAGE_TAG: ${{ needs.prepare-meta.outputs.imageTag }}
+          E2E_REF: ${{ inputs.branch }}
         shell: bash
         run: |
-          set -euo pipefail
+          set -uo pipefail
 
-          node scripts/resolve-e2e-targets.mjs \
+          log_file="$RUNNER_TEMP/e2e-resolve.log"
+          output_file="$RUNNER_TEMP/e2e-targets.json"
+          payload_file="$RUNNER_TEMP/e2e-dispatch-payload.json"
+
+          if node scripts/resolve-e2e-targets.mjs \
             --branch "${{ inputs.branch }}" \
             --repository "${{ inputs.repository || 'nocobase' }}" \
             --nocobase-pr-number "${{ inputs.nocobase_pr_number || '' }}" \
             --pro-plugin "${{ inputs.pro_plugin || '' }}" \
             --pro-pr-number "${{ inputs.pro_pr_number || '' }}" \
             --github-token "$GH_TOKEN" \
-            --output "$RUNNER_TEMP/e2e-targets.json" \
-            --github-output "$GITHUB_OUTPUT"
+            --output "$output_file" \
+            --github-output "$GITHUB_OUTPUT" > "$log_file" 2>&1
+          then
+            cat "$log_file"
 
-          {
-            echo "## E2E worker dispatch"
-            echo
-            echo "- image tag: ${{ needs.prepare-meta.outputs.imageTag }}"
-            echo "- e2e ref: ${{ inputs.branch }}"
-            echo "- target input: $(node -e "console.log(require(process.argv[1]).targetInput || '<none>')" "$RUNNER_TEMP/e2e-targets.json")"
-            echo "- changed files: $(node -e "console.log(require(process.argv[1]).changedFileCount)" "$RUNNER_TEMP/e2e-targets.json")"
-            echo
-            echo '```json'
-            cat "$RUNNER_TEMP/e2e-targets.json"
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
+            node scripts/write-e2e-dispatch-payload.mjs \
+              --summary "$output_file" \
+              --payload-output "$payload_file" \
+              --github-output "$GITHUB_OUTPUT"
+
+            {
+              echo "## E2E worker dispatch"
+              echo
+              echo "- image tag: $IMAGE_TAG"
+              echo "- e2e ref: $E2E_REF"
+              echo "- event type: $(node -e "console.log(require(process.argv[1]).event_type)" "$payload_file")"
+              echo "- target input: $(node -e "console.log(require(process.argv[1]).target_input || require(process.argv[1]).resolver?.target_input || '<none>')" "$payload_file")"
+              echo "- changed files: $(node -e "console.log(require(process.argv[1]).resolver?.changed_file_count ?? '<unknown>')" "$payload_file")"
+              echo
+              echo '```json'
+              cat "$output_file"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            cat "$log_file"
+            echo "::warning::E2E target resolver failed; dispatching worker notification."
+
+            node scripts/write-e2e-dispatch-payload.mjs \
+              --resolver-error-log "$log_file" \
+              --payload-output "$payload_file" \
+              --github-output "$GITHUB_OUTPUT"
+
+            {
+              echo "## E2E worker dispatch"
+              echo
+              echo "- image tag: $IMAGE_TAG"
+              echo "- e2e ref: $E2E_REF"
+              echo "- event type: resolver_failed"
+              echo
+              echo '```text'
+              cat "$log_file"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Dispatch E2E worker
-        if: ${{ steps.resolve-e2e.outcome == 'success' && steps.resolve-e2e.outputs.should_run == 'true' }}
+        if: ${{ always() && steps.resolve-e2e.outputs.dispatch_payload != '' }}
         env:
           GH_TOKEN: ${{ secrets.E2E_WORKER_TOKEN }}
-          TARGETS: ${{ steps.resolve-e2e.outputs.target_input }}
-          E2E_REF: ${{ steps.resolve-e2e.outputs.e2e_ref }}
+          TARGETS: ${{ steps.resolve-e2e.outputs.target_input || '__notification__' }}
+          E2E_REF: ${{ steps.resolve-e2e.outputs.e2e_ref || inputs.branch }}
+          DISPATCH_PAYLOAD: ${{ steps.resolve-e2e.outputs.dispatch_payload }}
         shell: bash
         run: |
           set -euo pipefail
@@ -987,12 +1027,18 @@ jobs:
             -f dispatch_id="build-pro-${{ github.run_id }}-${{ github.run_attempt }}" \
             -f caller_repo="${{ github.repository }}" \
             -f caller_run_id="${{ github.run_id }}" \
-            -f caller_sha="${{ github.sha }}"
+            -f caller_sha="${{ github.sha }}" \
+            -f dispatch_payload="$DISPATCH_PAYLOAD"
           then
             {
               echo
               echo "Dispatched E2E worker:"
               echo "https://github.com/Charls-Wu/nocobase-e2e-ci/actions/workflows/e2e.yml"
+              echo
+              echo "Payload:"
+              echo '```json'
+              echo "$DISPATCH_PAYLOAD"
+              echo '```'
             } >> "$GITHUB_STEP_SUMMARY"
           else
             echo "::warning::Failed to dispatch E2E worker; image build result is not affected."
@@ -1001,11 +1047,16 @@ jobs:
               echo
               echo "Failed to dispatch E2E worker. Image build result is not affected."
               echo "Check E2E_WORKER_TOKEN permissions and worker workflow availability."
+              echo
+              echo "Payload:"
+              echo '```json'
+              echo "$DISPATCH_PAYLOAD"
+              echo '```'
             } >> "$GITHUB_STEP_SUMMARY"
           fi
 
-      - name: Skip E2E worker
-        if: ${{ always() && (steps.resolve-e2e.outcome != 'success' || steps.resolve-e2e.outputs.should_run != 'true') }}
+      - name: Write E2E dispatch skip summary
+        if: ${{ always() && steps.resolve-e2e.outputs.dispatch_payload == '' }}
         shell: bash
         run: |
           {
@@ -1014,8 +1065,7 @@ jobs:
             echo "E2E worker was not dispatched."
             echo
             echo "- resolver outcome: ${{ steps.resolve-e2e.outcome }}"
-            echo "- should run: ${{ steps.resolve-e2e.outputs.should_run || 'false' }}"
-            echo "- skipped reason: ${{ steps.resolve-e2e.outputs.skipped_reason || 'resolver-failed' }}"
+            echo "- reason: dispatch payload was not created"
           } >> "$GITHUB_STEP_SUMMARY"
 
   update-status:

--- a/.github/workflows/build-pro-image.yml
+++ b/.github/workflows/build-pro-image.yml
@@ -909,6 +909,115 @@ jobs:
                 \"dialect\": \"postgres\"
             }"
 
+  dispatch-e2e:
+    if: ${{ always() && contains(fromJSON('["main","next","develop"]'), inputs.branch) && needs.assemble-image.result == 'success' }}
+    runs-on: ubuntu-latest
+    needs: [ get-plugins, prepare-meta, assemble-image ]
+    continue-on-error: true
+    steps:
+      - name: Checkout nocobase-ci
+        uses: actions/checkout@v5
+
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.NOCOBASE_APP_ID }}
+          private-key: ${{ secrets.NOCOBASE_APP_PRIVATE_KEY }}
+          owner: nocobase
+          repositories: nocobase,pro-plugins,${{ inputs.repository || 'nocobase' }},${{
+            join(fromJSON(needs.get-plugins.outputs.all-plugins || '[]'), ',')
+            }}
+          skip-token-revoke: true
+
+      - name: Resolve E2E targets
+        id: resolve-e2e
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          node scripts/resolve-e2e-targets.mjs \
+            --branch "${{ inputs.branch }}" \
+            --repository "${{ inputs.repository || 'nocobase' }}" \
+            --nocobase-pr-number "${{ inputs.nocobase_pr_number || '' }}" \
+            --pro-plugin "${{ inputs.pro_plugin || '' }}" \
+            --pro-pr-number "${{ inputs.pro_pr_number || '' }}" \
+            --github-token "$GH_TOKEN" \
+            --output "$RUNNER_TEMP/e2e-targets.json" \
+            --github-output "$GITHUB_OUTPUT"
+
+          {
+            echo "## E2E worker dispatch"
+            echo
+            echo "- image tag: ${{ needs.prepare-meta.outputs.imageTag }}"
+            echo "- e2e ref: ${{ inputs.branch }}"
+            echo "- target input: $(node -e "console.log(require(process.argv[1]).targetInput || '<none>')" "$RUNNER_TEMP/e2e-targets.json")"
+            echo "- changed files: $(node -e "console.log(require(process.argv[1]).changedFileCount)" "$RUNNER_TEMP/e2e-targets.json")"
+            echo
+            echo '```json'
+            cat "$RUNNER_TEMP/e2e-targets.json"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Dispatch E2E worker
+        if: ${{ steps.resolve-e2e.outcome == 'success' && steps.resolve-e2e.outputs.should_run == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.E2E_WORKER_TOKEN }}
+          TARGETS: ${{ steps.resolve-e2e.outputs.target_input }}
+          E2E_REF: ${{ steps.resolve-e2e.outputs.e2e_ref }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::warning::E2E_WORKER_TOKEN is not configured; skip E2E worker dispatch."
+            exit 0
+          fi
+
+          if gh workflow run e2e.yml \
+            --repo Charls-Wu/nocobase-e2e-ci \
+            --ref main \
+            -f targets="$TARGETS" \
+            -f nocobase_version="${{ needs.prepare-meta.outputs.imageTag }}" \
+            -f e2e_repo=nocobase/e2e \
+            -f e2e_ref="$E2E_REF" \
+            -f dry_run=false \
+            -f dispatch_id="build-pro-${{ github.run_id }}-${{ github.run_attempt }}" \
+            -f caller_repo="${{ github.repository }}" \
+            -f caller_run_id="${{ github.run_id }}" \
+            -f caller_sha="${{ github.sha }}"
+          then
+            {
+              echo
+              echo "Dispatched E2E worker:"
+              echo "https://github.com/Charls-Wu/nocobase-e2e-ci/actions/workflows/e2e.yml"
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::warning::Failed to dispatch E2E worker; image build result is not affected."
+
+            {
+              echo
+              echo "Failed to dispatch E2E worker. Image build result is not affected."
+              echo "Check E2E_WORKER_TOKEN permissions and worker workflow availability."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Skip E2E worker
+        if: ${{ always() && (steps.resolve-e2e.outcome != 'success' || steps.resolve-e2e.outputs.should_run != 'true') }}
+        shell: bash
+        run: |
+          {
+            echo "## E2E worker dispatch"
+            echo
+            echo "E2E worker was not dispatched."
+            echo
+            echo "- resolver outcome: ${{ steps.resolve-e2e.outcome }}"
+            echo "- should run: ${{ steps.resolve-e2e.outputs.should_run || 'false' }}"
+            echo "- skipped reason: ${{ steps.resolve-e2e.outputs.skipped_reason || 'resolver-failed' }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   update-status:
     if: ${{ inputs.checkRunId && always() }}
     runs-on: ubuntu-latest

--- a/scripts/resolve-e2e-targets.mjs
+++ b/scripts/resolve-e2e-targets.mjs
@@ -1,0 +1,367 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const SUPPORTED_E2E_REFS = new Set(['main', 'next', 'develop']);
+
+function usage() {
+  console.error(`Usage:
+  node scripts/resolve-e2e-targets.mjs \\
+    --branch <branch> \\
+    --repository <repository> \\
+    [--nocobase-pr-number <number>] \\
+    [--pro-plugin <name>] \\
+    [--pro-pr-number <number>] \\
+    [--github-token <token>] \\
+    [--output <file>] \\
+    [--github-output <file>]
+`);
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 2; i < argv.length; i += 1) {
+    const key = argv[i];
+    const value = argv[i + 1];
+    if (!key.startsWith('--') || value === undefined || value.startsWith('--')) {
+      usage();
+      process.exit(2);
+    }
+    args[key.slice(2)] = value;
+    i += 1;
+  }
+  return args;
+}
+
+function clean(value) {
+  return String(value || '').trim();
+}
+
+function normalizeRepoName(repo) {
+  return clean(repo).replace(/^nocobase\//, '');
+}
+
+function deriveRepository(args) {
+  const repository = normalizeRepoName(args.repository);
+  if (repository) {
+    return repository;
+  }
+
+  const proPlugin = clean(args['pro-plugin']);
+  if (!proPlugin) {
+    return 'nocobase';
+  }
+
+  if (proPlugin === 'pro-plugins') {
+    return 'pro-plugins';
+  }
+
+  return proPlugin.startsWith('plugin-') ? proPlugin : `plugin-${proPlugin}`;
+}
+
+function githubHeaders(token) {
+  const headers = {
+    Accept: 'application/vnd.github+json',
+    'User-Agent': 'nocobase-e2e-target-resolver',
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
+
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  return headers;
+}
+
+async function githubJson(url, token) {
+  const response = await fetch(url, { headers: githubHeaders(token) });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`GitHub API failed: ${response.status} ${response.statusText} ${url}\n${body}`);
+  }
+  return response.json();
+}
+
+function repoApiPath(fullName) {
+  return fullName.split('/').map(encodeURIComponent).join('/');
+}
+
+async function listPullRequestFiles(fullName, prNumber, token) {
+  const files = [];
+  for (let page = 1; ; page += 1) {
+    const url = `https://api.github.com/repos/${repoApiPath(fullName)}/pulls/${encodeURIComponent(prNumber)}/files?per_page=100&page=${page}`;
+    const batch = await githubJson(url, token);
+    files.push(...batch.map((file) => file.filename));
+    if (batch.length < 100) {
+      return files;
+    }
+  }
+}
+
+async function listLatestCommitFiles(fullName, branch, token) {
+  const url = `https://api.github.com/repos/${repoApiPath(fullName)}/commits/${encodeURIComponent(branch)}`;
+  const commit = await githubJson(url, token);
+  return (commit.files || []).map((file) => file.filename);
+}
+
+function deriveSources(args) {
+  const branch = clean(args.branch);
+  const repository = deriveRepository(args);
+  const nocobasePrNumber = clean(args['nocobase-pr-number']);
+  const proPrNumber = clean(args['pro-pr-number']);
+
+  if (!branch) {
+    throw new Error('branch is required');
+  }
+
+  const sources = [];
+
+  if (repository === 'nocobase') {
+    sources.push({
+      sourceRepo: 'nocobase',
+      sourceFullName: 'nocobase/nocobase',
+      triggerType: nocobasePrNumber ? 'main-repo-pr' : 'main-repo-branch',
+      prNumber: nocobasePrNumber,
+      branch,
+    });
+    return sources;
+  }
+
+  sources.push({
+    sourceRepo: repository,
+    sourceFullName: `nocobase/${repository}`,
+    triggerType: proPrNumber ? 'plugin-repo-pr' : 'plugin-repo-branch',
+    prNumber: proPrNumber,
+    branch,
+  });
+
+  if (nocobasePrNumber) {
+    sources.push({
+      sourceRepo: 'nocobase',
+      sourceFullName: 'nocobase/nocobase',
+      triggerType: 'main-repo-pr',
+      prNumber: nocobasePrNumber,
+      branch,
+    });
+  }
+
+  return sources;
+}
+
+async function collectChangedFiles(source, token) {
+  const files = source.prNumber
+    ? await listPullRequestFiles(source.sourceFullName, source.prNumber, token)
+    : await listLatestCommitFiles(source.sourceFullName, source.branch, token);
+
+  return {
+    ...source,
+    files,
+  };
+}
+
+function isIgnoredFile(file) {
+  return (
+    file === '.gitignore' ||
+    file === '.ignore' ||
+    file === '.node-version' ||
+    file === 'README.md' ||
+    file.startsWith('.github/') ||
+    file.startsWith('docs/') ||
+    file.endsWith('.md')
+  );
+}
+
+function createResolution() {
+  return {
+    all: false,
+    targets: new Set(),
+    matched: [],
+    ignored: [],
+  };
+}
+
+function addTarget(result, source, file, target, rule) {
+  result.targets.add(target);
+  result.matched.push({
+    sourceRepo: source.sourceRepo,
+    triggerType: source.triggerType,
+    file,
+    target,
+    rule,
+  });
+}
+
+function addAll(result, source, file, rule) {
+  result.all = true;
+  result.matched.push({
+    sourceRepo: source.sourceRepo,
+    triggerType: source.triggerType,
+    file,
+    target: '*',
+    rule,
+  });
+}
+
+function ignoreFile(result, source, file, reason) {
+  result.ignored.push({
+    sourceRepo: source.sourceRepo,
+    triggerType: source.triggerType,
+    file,
+    reason,
+  });
+}
+
+function resolveNocobaseFile(result, source, file) {
+  if (isIgnoredFile(file)) {
+    ignoreFile(result, source, file, 'ignored-doc-or-config');
+    return;
+  }
+
+  const pluginMatch = file.match(/^packages\/plugins\/@nocobase\/([^/]+)\//);
+  if (pluginMatch) {
+    addTarget(result, source, file, pluginMatch[1], 'main-repo-plugin-path');
+    return;
+  }
+
+  addAll(result, source, file, 'main-repo-runtime-or-shared-change');
+}
+
+function resolveProPluginsFile(result, source, file) {
+  if (isIgnoredFile(file)) {
+    ignoreFile(result, source, file, 'ignored-doc-or-config');
+    return;
+  }
+
+  const scopedPluginMatch = file.match(/^@nocobase\/([^/]+)\//);
+  if (scopedPluginMatch) {
+    addTarget(result, source, file, scopedPluginMatch[1], 'pro-plugins-scoped-plugin-path');
+    return;
+  }
+
+  const packageMatch = file.match(/^([^/.][^/]+)\//);
+  if (packageMatch) {
+    addTarget(result, source, file, packageMatch[1], 'pro-plugins-package-path');
+    return;
+  }
+
+  addAll(result, source, file, 'pro-plugins-root-or-shared-change');
+}
+
+function resolveStandalonePluginFile(result, source, file) {
+  if (isIgnoredFile(file)) {
+    ignoreFile(result, source, file, 'ignored-doc-or-config');
+    return;
+  }
+
+  addTarget(result, source, file, source.sourceRepo, 'standalone-plugin-repo-change');
+}
+
+function resolveSourceFiles(result, source) {
+  for (const file of source.files) {
+    if (source.sourceRepo === 'nocobase') {
+      resolveNocobaseFile(result, source, file);
+    } else if (source.sourceRepo === 'pro-plugins') {
+      resolveProPluginsFile(result, source, file);
+    } else {
+      resolveStandalonePluginFile(result, source, file);
+    }
+  }
+}
+
+function writeGithubOutput(file, outputs) {
+  if (!file) {
+    return;
+  }
+
+  const lines = [];
+  for (const [key, value] of Object.entries(outputs)) {
+    if (Array.isArray(value)) {
+      lines.push(`${key}<<EOF`);
+      lines.push(...value);
+      lines.push('EOF');
+    } else {
+      lines.push(`${key}=${value}`);
+    }
+  }
+  fs.appendFileSync(file, `${lines.join('\n')}\n`);
+}
+
+try {
+  const args = parseArgs(process.argv);
+  const branch = clean(args.branch);
+  const token = clean(args['github-token']) || clean(process.env.GITHUB_TOKEN);
+  const outputFile = args.output ? path.resolve(args.output) : '';
+  const githubOutputFile = args['github-output'] ? path.resolve(args['github-output']) : '';
+  const e2eRefSupported = SUPPORTED_E2E_REFS.has(branch);
+  const sources = deriveSources(args);
+  const sourcesWithFiles = [];
+  const resolution = createResolution();
+
+  for (const source of sources) {
+    const sourceWithFiles = await collectChangedFiles(source, token);
+    sourcesWithFiles.push(sourceWithFiles);
+    resolveSourceFiles(resolution, sourceWithFiles);
+  }
+
+  const targets = [...resolution.targets].sort();
+  const mode = resolution.all ? 'all' : targets.length > 0 ? 'packages' : 'none';
+  const targetInput = resolution.all ? '*' : targets.join(',');
+  const shouldRun = e2eRefSupported && Boolean(targetInput);
+  const skippedReason = !e2eRefSupported
+    ? 'unsupported-e2e-ref'
+    : targetInput
+      ? ''
+      : 'no-e2e-targets';
+  const changedFileCount = sourcesWithFiles.reduce((count, source) => count + source.files.length, 0);
+  const summary = {
+    branch,
+    e2eRef: branch,
+    e2eRefSupported,
+    mode,
+    shouldRun,
+    skippedReason,
+    targetInput,
+    targets,
+    changedFileCount,
+    sources: sourcesWithFiles.map((source) => ({
+      sourceRepo: source.sourceRepo,
+      sourceFullName: source.sourceFullName,
+      triggerType: source.triggerType,
+      prNumber: source.prNumber,
+      changedFileCount: source.files.length,
+    })),
+    matched: resolution.matched,
+    ignored: resolution.ignored,
+  };
+
+  if (outputFile) {
+    fs.writeFileSync(outputFile, `${JSON.stringify(summary, null, 2)}\n`);
+  }
+
+  writeGithubOutput(githubOutputFile, {
+    mode,
+    should_run: String(shouldRun),
+    skipped_reason: skippedReason,
+    target_input: targetInput,
+    e2e_ref: branch,
+    e2e_ref_supported: String(e2eRefSupported),
+    targets,
+    changed_file_count: String(changedFileCount),
+  });
+
+  console.log(`E2E ref: ${branch}`);
+  console.log(`E2E ref supported: ${e2eRefSupported}`);
+  console.log(`Changed files: ${changedFileCount}`);
+  console.log(`Mode: ${mode}`);
+  console.log(`Target input: ${targetInput || '<none>'}`);
+  if (skippedReason) {
+    console.log(`Skipped reason: ${skippedReason}`);
+  }
+  for (const source of summary.sources) {
+    console.log(`Source: ${source.sourceFullName} (${source.triggerType}), changed files: ${source.changedFileCount}`);
+  }
+} catch (error) {
+  console.error(`::error::${error.message}`);
+  process.exit(1);
+}

--- a/scripts/resolve-e2e-targets.mjs
+++ b/scripts/resolve-e2e-targets.mjs
@@ -4,6 +4,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 const SUPPORTED_E2E_REFS = new Set(['main', 'next', 'develop']);
+const IGNORED_DOC_OR_CONFIG_RULE = 'ignored-doc-or-config';
+const IGNORED_DOC_OR_CONFIG_SCOPE = 'docs/**、.github/**、*.md、README.md、.node-version 等文档或配置文件变更不触发 E2E。';
 
 function usage() {
   console.error(`Usage:
@@ -181,6 +183,34 @@ function createResolution() {
   };
 }
 
+function skippedDetail(skippedReason, changedFileCount, ignoredCount) {
+  if (skippedReason !== 'no-e2e-targets') {
+    return {
+      reasonText: skippedReason || '',
+      ruleScope: '',
+    };
+  }
+
+  if (changedFileCount === 0) {
+    return {
+      reasonText: 'changed files 为空，没有需要触发的 E2E target。',
+      ruleScope: '',
+    };
+  }
+
+  if (ignoredCount === changedFileCount) {
+    return {
+      reasonText: `所有 changed files 都命中 ${IGNORED_DOC_OR_CONFIG_RULE} 规则。`,
+      ruleScope: IGNORED_DOC_OR_CONFIG_SCOPE,
+    };
+  }
+
+  return {
+    reasonText: '解析成功，但没有匹配到需要触发 E2E 的 target。',
+    ruleScope: '',
+  };
+}
+
 function addTarget(result, source, file, target, rule) {
   result.targets.add(target);
   result.matched.push({
@@ -314,6 +344,7 @@ try {
       ? ''
       : 'no-e2e-targets';
   const changedFileCount = sourcesWithFiles.reduce((count, source) => count + source.files.length, 0);
+  const skip = skippedDetail(skippedReason, changedFileCount, resolution.ignored.length);
   const summary = {
     branch,
     e2eRef: branch,
@@ -324,6 +355,8 @@ try {
     targetInput,
     targets,
     changedFileCount,
+    skipReasonText: skip.reasonText,
+    skipRuleScope: skip.ruleScope,
     sources: sourcesWithFiles.map((source) => ({
       sourceRepo: source.sourceRepo,
       sourceFullName: source.sourceFullName,
@@ -343,6 +376,8 @@ try {
     mode,
     should_run: String(shouldRun),
     skipped_reason: skippedReason,
+    skip_reason_text: skip.reasonText,
+    skip_rule_scope: skip.ruleScope,
     target_input: targetInput,
     e2e_ref: branch,
     e2e_ref_supported: String(e2eRefSupported),

--- a/scripts/write-e2e-dispatch-payload.mjs
+++ b/scripts/write-e2e-dispatch-payload.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+function usage() {
+  console.error(`Usage:
+  node scripts/write-e2e-dispatch-payload.mjs \\
+    [--summary <file> | --resolver-error-log <file>] \\
+    --payload-output <file> \\
+    [--github-output <file>]
+`);
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 2; i < argv.length; i += 1) {
+    const key = argv[i];
+    const value = argv[i + 1];
+    if (!key.startsWith('--') || value === undefined || value.startsWith('--')) {
+      usage();
+      process.exit(2);
+    }
+    args[key.slice(2)] = value;
+    i += 1;
+  }
+  return args;
+}
+
+function env(name) {
+  return process.env[name] || '';
+}
+
+function basePayload(eventType) {
+  return {
+    event_type: eventType,
+    dispatch_id: env('DISPATCH_ID'),
+    caller: {
+      repo: env('CALLER_REPO'),
+      run_id: env('CALLER_RUN_ID'),
+      sha: env('CALLER_SHA'),
+    },
+  };
+}
+
+function payloadFromSummary(summaryFile) {
+  const summary = JSON.parse(fs.readFileSync(summaryFile, 'utf8'));
+  const eventType = summary.shouldRun ? 'test' : 'skipped';
+
+  return {
+    ...basePayload(eventType),
+    resolver: {
+      mode: summary.mode,
+      target_input: summary.targetInput,
+      skipped_reason: summary.skippedReason,
+      reason_text: summary.skipReasonText,
+      rule_scope: summary.skipRuleScope,
+      changed_file_count: summary.changedFileCount,
+      sources: summary.sources,
+    },
+  };
+}
+
+function payloadFromResolverError(logFile) {
+  const log = fs.existsSync(logFile) ? fs.readFileSync(logFile, 'utf8').trim() : '';
+  return {
+    ...basePayload('resolver_failed'),
+    resolver: {
+      error: log || 'E2E target resolver failed without output.',
+    },
+  };
+}
+
+function writeGithubOutput(file, outputs) {
+  if (!file) {
+    return;
+  }
+
+  const lines = [];
+  for (const [key, value] of Object.entries(outputs)) {
+    if (String(value).includes('\n')) {
+      lines.push(`${key}<<EOF`);
+      lines.push(value);
+      lines.push('EOF');
+    } else {
+      lines.push(`${key}=${value}`);
+    }
+  }
+  fs.appendFileSync(file, `${lines.join('\n')}\n`);
+}
+
+try {
+  const args = parseArgs(process.argv);
+  const payloadOutput = args['payload-output'] ? path.resolve(args['payload-output']) : '';
+  if (!payloadOutput) {
+    throw new Error('--payload-output is required');
+  }
+
+  const payload = args.summary
+    ? payloadFromSummary(path.resolve(args.summary))
+    : payloadFromResolverError(path.resolve(args['resolver-error-log'] || ''));
+
+  const payloadJson = JSON.stringify(payload);
+  fs.writeFileSync(payloadOutput, `${payloadJson}\n`);
+
+  const outputs = {
+    dispatch_payload: payloadJson,
+  };
+  if (payload.event_type === 'resolver_failed') {
+    outputs.should_run = 'false';
+    outputs.skipped_reason = 'resolver-failed';
+    outputs.e2e_ref = env('E2E_REF');
+  }
+  writeGithubOutput(args['github-output'] ? path.resolve(args['github-output']) : '', outputs);
+
+  console.log(`Dispatch payload event type: ${payload.event_type}`);
+} catch (error) {
+  console.error(`::error::${error.message}`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

- add a non-blocking `dispatch-e2e` job after `assemble-image` succeeds
- resolve upstream changed files into E2E worker `targets`
- dispatch `Charls-Wu/nocobase-e2e-ci` with image tag, E2E ref, caller metadata, and resolved targets

## Safety

- existing build jobs are not changed
- `update-status` does not depend on `dispatch-e2e`
- the new job is `continue-on-error: true`
- worker dispatch failures only emit warnings and do not affect image build results

## Target rules

- `nocobase/nocobase`: `packages/plugins/@nocobase/<name>/...` -> `<name>`, shared/runtime changes -> `*`
- `nocobase/pro-plugins`: `@nocobase/<name>/...` or `<name>/...` -> `<name>`, root/shared changes -> `*`
- standalone plugin repos: any non-ignored source change -> repository name
- `main`, `next`, `develop` map directly to the same E2E branch

## Local validation

- `node --check scripts/resolve-e2e-targets.mjs`
- YAML parsed successfully with PyYAML
- `git diff --cached --check`
- sample resolutions:
  - `nocobase/nocobase#8743` on `main` -> `*`
  - `nocobase/pro-plugins#520` on `main` -> `plugin-action-import-pro`
  - `nocobase/plugin-backups#39` on `next` -> `plugin-backups`

## Required secret

`E2E_WORKER_TOKEN` must be configured in `2013xile/nocobase-ci` with permission to dispatch workflows in `Charls-Wu/nocobase-e2e-ci`.